### PR TITLE
Fixes possibility of having an issue with the tokens.

### DIFF
--- a/samsungctl/remote_websocket.py
+++ b/samsungctl/remote_websocket.py
@@ -63,7 +63,7 @@ class RemoteWebsocket(websocket.WebSocketApp):
             for line in tokens.split('\n'):
                 if not line.strip():
                     continue
-                if line.startswith(self.config["host"]):
+                if line.startswith(self.config["host"] + ':'):
                     token = line
                 else:
                     all_tokens += [line]
@@ -178,7 +178,7 @@ class RemoteWebsocket(websocket.WebSocketApp):
                     token_data = token_file.read().split('\n')
 
                 for line in token_data[:]:
-                    if self.config['host'] in line:
+                    if line.startswith(self.config['host'] + ':'):
                         token_data.remove(line)
 
                 token_data += [token]


### PR DESCRIPTION
when iterating over the token file i was checking to see if the line
began with the IP address. not thinking about

192.168.1.1
192.168.1.11
192.168.1.111

would all be considered the same if the connected TV had an IP of
192.168.1.1. the token is separated by a :

192.168.1.1:TOKENDATA
192.168.1.11:TOKENDATA

so now i check if the line starts with IP:

This error was reported by @flubshi in #11