### PR TITLE
fixes missing sock attribute

### DIFF
--- a/samsungctl/remote_websocket.py
+++ b/samsungctl/remote_websocket.py
@@ -45,6 +45,7 @@ class RemoteWebsocket(websocket.WebSocketApp):
         self.receive_event = threading.Event()
         self.receive_lock = threading.Lock()
         self.close_event = threading.Event()
+        self.sock = None
 
         self.open()
 


### PR DESCRIPTION
websocket.WebsocketApp has an attribute sock that is used to tell if
the connection has been made. I was trying to check this attribute
before I initialized the class. So I added self.sock = None to the __init__ of
RemoteWebsocket to handle this issue.

Reported by @teeedubb in #12