### PR TITLE
fixed error: AttributeError: 'NoneType' object has no attribute 'host'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 dist/
+.ropeproject
 *.egg-info/
 *.pyc
 *.swp

--- a/samsungctl/config.py
+++ b/samsungctl/config.py
@@ -163,7 +163,9 @@ class Config(object):
             raise exceptions.ConfigLoadError
 
         self = super(Config, cls).__new__(cls, **config)
+        self.__init__(**config)
         self.path = path
+        return self
 
     def save(self, path=None):
         if path is None:


### PR DESCRIPTION
When executing Config.load(), the config class object (self) was being constructed with __ new __() but not being initialized with __ init __(**config) and was not being returned from the Config.load() class method.  I added these two missing steps to address the error in issue #51 

```
[root@homeassistant samsungctl]# /common/apps/homeassistant/bin/samsungctl --method=websocket --host=10.99.1.252 --config-file ~/.config/samsungctl.conf KEY_MENU
Traceback (most recent call last):
File "/common/apps/homeassistant/bin/samsungctl", line 11, in 
load_entry_point('samsungctl==0.8.0b0', 'console_scripts', 'samsungctl')()
File "/common/apps/homeassistant/lib/python3.6/site-packages/samsungctl-0.8.0b0-py3.6.egg/samsungctl/main.py", line 269, in main
if not config.host:
AttributeError: 'NoneType' object has no attribute 'host'
```

Hope this helps.  Let me know if you need help testing out your upnp addition to samsungctl. 

-Ty