### PR TITLE
Added path substitution for bash variables in config file path

### DIFF
--- a/samsungctl/config.py
+++ b/samsungctl/config.py
@@ -210,7 +210,7 @@ class Config(object):
     def load(path):
         if '~' in path:
             path.replace('~', os.path.expanduser('~'))
-        if '%' in path:
+        if '%' in path or '$' in path:
             path = os.path.expandvars(path)
 
         if os.path.isfile(path):


### PR DESCRIPTION
Adds path substitution when linux bash variables (starting with $) are present in config file path.